### PR TITLE
fix: PackageInjector behavior

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "external/dd-sdk-go-testing"]
+	path = external/dd-sdk-go-testing
+	url = https://github.com/DataDog/dd-sdk-go-testing.git
+	branch = tony/rd-autoinstrument

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,13 @@ module rd-toolexec
 
 go 1.22
 
-require golang.org/x/tools v0.19.0
+require (
+	github.com/stretchr/testify v1.9.0
+	golang.org/x/tools v0.19.0
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/tools v0.19.0 h1:tfGCXNR1OsFG+sVdLAitlpjAvD/I6dHDKnYrpEZUHkw=
+golang.org/x/tools v0.19.0/go.mod h1:qoJWxmGSIBmAeriMx19ogtrEPrGtDbPK634QFIcLAhc=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"os"
+	"path"
 	testAst "rd-toolexec/internal/ast"
 	"rd-toolexec/internal/toolexec/processors"
 	"rd-toolexec/internal/toolexec/proxy"
+	"runtime"
 	"strings"
 )
+
+var root string
 
 func main() {
 	cmdT := proxy.MustParseCommand(os.Args[1:])
@@ -16,7 +20,7 @@ func main() {
 		return
 	}
 
-	pkgInj := processors.NewPackageInjector(testAst.ImportPath, "/Users/tony.redondo/repos/github/Datadog/dd-sdk-go-testing/autoinstrument")
+	pkgInj := processors.NewPackageInjector(testAst.ImportPath, path.Join(root, "external", "dd-sdk-go-testing", "autoinstrument"))
 
 	if cmdT.Type() == proxy.CommandTypeCompile {
 		for idx, val := range cmdT.Args() {
@@ -118,4 +122,9 @@ func main() {
 		}
 
 	*/
+}
+
+func init() {
+	_, file, _, _ := runtime.Caller(0)
+	root = path.Dir(file)
 }


### PR DESCRIPTION
The PackageInjector artificially limits itself to stage `b001` but it seems like in `go test` scenarios, it actually needs to do work on some other stages as well. The Compile command processor in particular should run in all stages.